### PR TITLE
Support src and dst in `str` type and numerical value in double/long

### DIFF
--- a/python/MIDASWrapper.cpp
+++ b/python/MIDASWrapper.cpp
@@ -14,17 +14,17 @@ PYBIND11_MODULE(MIDAS, m) {
     m.doc() = "MIDAS wrapper";
 
     py::class_<MIDAS::NormalCore>(m, "MIDAS")
-            .def(py::init<unsigned long, unsigned long>(), py::arg("num_row"), py::arg("num_col"))
+            .def(py::init<int, int>(), py::arg("num_row"), py::arg("num_col"))
             .def("add_edge", &MIDAS::NormalCore::operator(), py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));
 
     py::class_<MIDAS::RelationalCore>(m, "MIDASR")
-            .def(py::init<unsigned long, unsigned long, float>(), py::arg("num_row"), py::arg("num_col"), py::arg("factor") = 0.5)
+            .def(py::init<int, int, float>(), py::arg("num_row"), py::arg("num_col"), py::arg("factor") = 0.5)
             .def("add_edge", &MIDAS::RelationalCore::operator(), py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));
 
     py::class_<MIDAS::FilteringCore>(m, "MIDASF")
-            .def(py::init<unsigned long, unsigned long, double, double>(), py::arg("num_row"), py::arg("num_col"), py::arg("threshold"),
+            .def(py::init<int, int, float, float>(), py::arg("num_row"), py::arg("num_col"), py::arg("threshold"),
                  py::arg("factor") = 0.5)
             .def("add_edge", &MIDAS::FilteringCore::operator(), py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));

--- a/python/MIDASWrapper.cpp
+++ b/python/MIDASWrapper.cpp
@@ -14,17 +14,17 @@ PYBIND11_MODULE(MIDAS, m) {
     m.doc() = "MIDAS wrapper";
 
     py::class_<MIDAS::NormalCore>(m, "MIDAS")
-            .def(py::init<int, int>(), py::arg("num_row"), py::arg("num_col"))
+            .def(py::init<unsigned long, unsigned long>(), py::arg("num_row"), py::arg("num_col"))
             .def("add_edge", &MIDAS::NormalCore::operator(), py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));
 
     py::class_<MIDAS::RelationalCore>(m, "MIDASR")
-            .def(py::init<int, int, float>(), py::arg("num_row"), py::arg("num_col"), py::arg("factor") = 0.5)
+            .def(py::init<unsigned long, unsigned long, float>(), py::arg("num_row"), py::arg("num_col"), py::arg("factor") = 0.5)
             .def("add_edge", &MIDAS::RelationalCore::operator(), py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));
 
     py::class_<MIDAS::FilteringCore>(m, "MIDASF")
-            .def(py::init<int, int, float, float>(), py::arg("num_row"), py::arg("num_col"), py::arg("threshold"),
+            .def(py::init<unsigned long, unsigned long, double, double>(), py::arg("num_row"), py::arg("num_col"), py::arg("threshold"),
                  py::arg("factor") = 0.5)
             .def("add_edge", &MIDAS::FilteringCore::operator(), py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));

--- a/python/MIDASWrapper.cpp
+++ b/python/MIDASWrapper.cpp
@@ -7,6 +7,7 @@
 #include <RelationalCore.hpp>
 #include <FilteringCore.hpp>
 #include <NormalCore.hpp>
+#include <string>
 
 namespace py = pybind11;
 
@@ -16,32 +17,32 @@ PYBIND11_MODULE(MIDAS, m) {
     py::class_<MIDAS::NormalCore>(m, "MIDAS")
             .def(py::init<int, int>(), py::arg("num_row"), py::arg("num_col"))
             .def("add_edge", static_cast<double (MIDAS::NormalCore::*)(unsigned long, unsigned long,
-                                                                      unsigned long)>(&MIDAS::NormalCore::operator()),
+                                                                       unsigned long)>(&MIDAS::NormalCore::operator()),
                  py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"))
-            .def("add_edge", static_cast<double (MIDAS::NormalCore::*)(const char *, const char *,
-                                                                      unsigned long)>(&MIDAS::NormalCore::operator()),
+            .def("add_edge", static_cast<double (MIDAS::NormalCore::*)(const std::string &, const std::string &,
+                                                                       unsigned long)>(&MIDAS::NormalCore::operator()),
                  py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));
 
     py::class_<MIDAS::RelationalCore>(m, "MIDASR")
             .def(py::init<int, int, double>(), py::arg("num_row"), py::arg("num_col"), py::arg("factor") = 0.5)
             .def("add_edge", static_cast<double (MIDAS::RelationalCore::*)(unsigned long, unsigned long,
-                                                                       unsigned long)>(&MIDAS::RelationalCore::operator()),
+                                                                           unsigned long)>(&MIDAS::RelationalCore::operator()),
                  py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"))
-            .def("add_edge", static_cast<double (MIDAS::RelationalCore::*)(const char *, const char *,
-                                                                       unsigned long)>(&MIDAS::RelationalCore::operator()),
+            .def("add_edge", static_cast<double (MIDAS::RelationalCore::*)(const std::string &, const std::string &,
+                                                                           unsigned long)>(&MIDAS::RelationalCore::operator()),
                  py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));
 
     py::class_<MIDAS::FilteringCore>(m, "MIDASF")
             .def("add_edge", static_cast<double (MIDAS::FilteringCore::*)(unsigned long, unsigned long,
-                                                                       unsigned long)>(&MIDAS::FilteringCore::operator()),
+                                                                          unsigned long)>(&MIDAS::FilteringCore::operator()),
                  py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"))
-            .def("add_edge", static_cast<double (MIDAS::FilteringCore::*)(const char *, const char *,
-                                                                       unsigned long)>(&MIDAS::FilteringCore::operator()),
+            .def("add_edge", static_cast<double (MIDAS::FilteringCore::*)(const std::string &, const std::string &,
+                                                                          unsigned long)>(&MIDAS::FilteringCore::operator()),
                  py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));
 }

--- a/python/MIDASWrapper.cpp
+++ b/python/MIDASWrapper.cpp
@@ -15,17 +15,33 @@ PYBIND11_MODULE(MIDAS, m) {
 
     py::class_<MIDAS::NormalCore>(m, "MIDAS")
             .def(py::init<int, int>(), py::arg("num_row"), py::arg("num_col"))
-            .def("add_edge", &MIDAS::NormalCore::operator(), py::arg("source"), py::arg("destination"),
+            .def("add_edge", static_cast<double (MIDAS::NormalCore::*)(unsigned long, unsigned long,
+                                                                      unsigned long)>(&MIDAS::NormalCore::operator()),
+                 py::arg("source"), py::arg("destination"),
+                 py::arg("timestamp"))
+            .def("add_edge", static_cast<double (MIDAS::NormalCore::*)(const char *, const char *,
+                                                                      unsigned long)>(&MIDAS::NormalCore::operator()),
+                 py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));
 
     py::class_<MIDAS::RelationalCore>(m, "MIDASR")
-            .def(py::init<int, int, float>(), py::arg("num_row"), py::arg("num_col"), py::arg("factor") = 0.5)
-            .def("add_edge", &MIDAS::RelationalCore::operator(), py::arg("source"), py::arg("destination"),
+            .def(py::init<int, int, double>(), py::arg("num_row"), py::arg("num_col"), py::arg("factor") = 0.5)
+            .def("add_edge", static_cast<double (MIDAS::RelationalCore::*)(unsigned long, unsigned long,
+                                                                       unsigned long)>(&MIDAS::RelationalCore::operator()),
+                 py::arg("source"), py::arg("destination"),
+                 py::arg("timestamp"))
+            .def("add_edge", static_cast<double (MIDAS::RelationalCore::*)(const char *, const char *,
+                                                                       unsigned long)>(&MIDAS::RelationalCore::operator()),
+                 py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));
 
     py::class_<MIDAS::FilteringCore>(m, "MIDASF")
-            .def(py::init<int, int, float, float>(), py::arg("num_row"), py::arg("num_col"), py::arg("threshold"),
-                 py::arg("factor") = 0.5)
-            .def("add_edge", &MIDAS::FilteringCore::operator(), py::arg("source"), py::arg("destination"),
+            .def("add_edge", static_cast<double (MIDAS::FilteringCore::*)(unsigned long, unsigned long,
+                                                                       unsigned long)>(&MIDAS::FilteringCore::operator()),
+                 py::arg("source"), py::arg("destination"),
+                 py::arg("timestamp"))
+            .def("add_edge", static_cast<double (MIDAS::FilteringCore::*)(const char *, const char *,
+                                                                       unsigned long)>(&MIDAS::FilteringCore::operator()),
+                 py::arg("source"), py::arg("destination"),
                  py::arg("timestamp"));
 }

--- a/src/CountMinSketch.hpp
+++ b/src/CountMinSketch.hpp
@@ -25,10 +25,10 @@ struct CountMinSketch {
 
 	const int r, c, m = 104729; // Yes, a magic number, I just pick a random prime
 	const int lenData;
-	unsigned long* const param1;
-	unsigned long* const param2;
-	double* const data;
-	constexpr static double infinity = std::numeric_limits<double>::infinity();
+	int* const param1;
+	int* const param2;
+	float* const data;
+	constexpr static float infinity = std::numeric_limits<float>::infinity();
 
 	// Methods
 	// --------------------------------------------------------------------------------
@@ -40,9 +40,9 @@ struct CountMinSketch {
 		r(numRow),
 		c(numColumn),
 		lenData(r * c),
-		param1(new unsigned long[r]),
-		param2(new unsigned long[r]),
-		data(new double[lenData]) {
+		param1(new int[r]),
+		param2(new int[r]),
+		data(new float[lenData]) {
 		for (int i = 0; i < r; i++) {
 			param1[i] = rand() + 1; // ×0 is not a good idea, see Hash()
 			param2[i] = rand();
@@ -54,9 +54,9 @@ struct CountMinSketch {
 		r(b.r),
 		c(b.c),
 		lenData(b.lenData),
-		param1(new unsigned long[r]),
-		param2(new unsigned long[r]),
-		data(new double[lenData]) {
+		param1(new int[r]),
+		param2(new int[r]),
+		data(new float[lenData]) {
 		std::copy(b.param1, b.param1 + r, param1);
 		std::copy(b.param2, b.param2 + r, param2);
 		std::copy(b.data, b.data + lenData, data);
@@ -68,36 +68,36 @@ struct CountMinSketch {
 		delete[] data;
 	}
 
-	void ClearAll(double with = 0) const {
+	void ClearAll(float with = 0) const {
 		std::fill(data, data + lenData, with);
 	}
 
-	void MultiplyAll(double by) const {
+	void MultiplyAll(float by) const {
 		for (int i = 0, I = lenData; i < I; i++) // Vectorization
 			data[i] *= by;
 	}
 
-	void Hash(unsigned long* indexOut, unsigned long a, unsigned long b = 0) const {
+	void Hash(int* indexOut, int a, int b = 0) const {
 		for (int i = 0; i < r; i++) {
 			indexOut[i] = ((a + m * b) * param1[i] + param2[i]) % c;
 			indexOut[i] += i * c + (indexOut[i] < 0 ? c : 0);
 		}
 	}
 
-	double operator()(const unsigned long* index) const {
-		double least = infinity;
+	float operator()(const int* index) const {
+		float least = infinity;
 		for (int i = 0; i < r; i++)
 			least = std::min(least, data[index[i]]);
 		return least;
 	}
 
-	double Assign(const unsigned long* index, double with) const {
+	float Assign(const int* index, float with) const {
 		for (int i = 0; i < r; i++)
 			data[index[i]] = with;
 		return with;
 	}
 
-	void Add(const unsigned long* index, double by = 1) const {
+	void Add(const int* index, float by = 1) const {
 		for (int i = 0; i < r; i++)
 			data[index[i]] += by;
 	}

--- a/src/CountMinSketch.hpp
+++ b/src/CountMinSketch.hpp
@@ -27,8 +27,8 @@ struct CountMinSketch {
 	const int lenData;
 	int* const param1;
 	int* const param2;
-	float* const data;
-	constexpr static float infinity = std::numeric_limits<float>::infinity();
+	double* const data;
+	constexpr static double infinity = std::numeric_limits<double>::infinity();
 
 	// Methods
 	// --------------------------------------------------------------------------------
@@ -42,7 +42,7 @@ struct CountMinSketch {
 		lenData(r * c),
 		param1(new int[r]),
 		param2(new int[r]),
-		data(new float[lenData]) {
+		data(new double[lenData]) {
 		for (int i = 0; i < r; i++) {
 			param1[i] = rand() + 1; // ×0 is not a good idea, see Hash()
 			param2[i] = rand();
@@ -56,7 +56,7 @@ struct CountMinSketch {
 		lenData(b.lenData),
 		param1(new int[r]),
 		param2(new int[r]),
-		data(new float[lenData]) {
+		data(new double[lenData]) {
 		std::copy(b.param1, b.param1 + r, param1);
 		std::copy(b.param2, b.param2 + r, param2);
 		std::copy(b.data, b.data + lenData, data);
@@ -68,36 +68,36 @@ struct CountMinSketch {
 		delete[] data;
 	}
 
-	void ClearAll(float with = 0) const {
+	void ClearAll(double with = 0) const {
 		std::fill(data, data + lenData, with);
 	}
 
-	void MultiplyAll(float by) const {
+	void MultiplyAll(double by) const {
 		for (int i = 0, I = lenData; i < I; i++) // Vectorization
 			data[i] *= by;
 	}
 
-	void Hash(int* indexOut, int a, int b = 0) const {
+	void Hash(unsigned long* indexOut, unsigned long a, unsigned long b = 0) const {
 		for (int i = 0; i < r; i++) {
 			indexOut[i] = ((a + m * b) * param1[i] + param2[i]) % c;
 			indexOut[i] += i * c + (indexOut[i] < 0 ? c : 0);
 		}
 	}
 
-	float operator()(const int* index) const {
-		float least = infinity;
+	double operator()(const unsigned long* index) const {
+		double least = infinity;
 		for (int i = 0; i < r; i++)
 			least = std::min(least, data[index[i]]);
 		return least;
 	}
 
-	float Assign(const int* index, float with) const {
+	double Assign(const unsigned long* index, double with) const {
 		for (int i = 0; i < r; i++)
 			data[index[i]] = with;
 		return with;
 	}
 
-	void Add(const int* index, float by = 1) const {
+	void Add(const unsigned long* index, double by = 1) const {
 		for (int i = 0; i < r; i++)
 			data[index[i]] += by;
 	}

--- a/src/CountMinSketch.hpp
+++ b/src/CountMinSketch.hpp
@@ -25,10 +25,10 @@ struct CountMinSketch {
 
 	const int r, c, m = 104729; // Yes, a magic number, I just pick a random prime
 	const int lenData;
-	int* const param1;
-	int* const param2;
-	float* const data;
-	constexpr static float infinity = std::numeric_limits<float>::infinity();
+	unsigned long* const param1;
+	unsigned long* const param2;
+	double* const data;
+	constexpr static double infinity = std::numeric_limits<double>::infinity();
 
 	// Methods
 	// --------------------------------------------------------------------------------
@@ -40,9 +40,9 @@ struct CountMinSketch {
 		r(numRow),
 		c(numColumn),
 		lenData(r * c),
-		param1(new int[r]),
-		param2(new int[r]),
-		data(new float[lenData]) {
+		param1(new unsigned long[r]),
+		param2(new unsigned long[r]),
+		data(new double[lenData]) {
 		for (int i = 0; i < r; i++) {
 			param1[i] = rand() + 1; // ×0 is not a good idea, see Hash()
 			param2[i] = rand();
@@ -54,9 +54,9 @@ struct CountMinSketch {
 		r(b.r),
 		c(b.c),
 		lenData(b.lenData),
-		param1(new int[r]),
-		param2(new int[r]),
-		data(new float[lenData]) {
+		param1(new unsigned long[r]),
+		param2(new unsigned long[r]),
+		data(new double[lenData]) {
 		std::copy(b.param1, b.param1 + r, param1);
 		std::copy(b.param2, b.param2 + r, param2);
 		std::copy(b.data, b.data + lenData, data);
@@ -68,36 +68,36 @@ struct CountMinSketch {
 		delete[] data;
 	}
 
-	void ClearAll(float with = 0) const {
+	void ClearAll(double with = 0) const {
 		std::fill(data, data + lenData, with);
 	}
 
-	void MultiplyAll(float by) const {
+	void MultiplyAll(double by) const {
 		for (int i = 0, I = lenData; i < I; i++) // Vectorization
 			data[i] *= by;
 	}
 
-	void Hash(int* indexOut, int a, int b = 0) const {
+	void Hash(unsigned long* indexOut, unsigned long a, unsigned long b = 0) const {
 		for (int i = 0; i < r; i++) {
 			indexOut[i] = ((a + m * b) * param1[i] + param2[i]) % c;
 			indexOut[i] += i * c + (indexOut[i] < 0 ? c : 0);
 		}
 	}
 
-	float operator()(const int* index) const {
-		float least = infinity;
+	double operator()(const unsigned long* index) const {
+		double least = infinity;
 		for (int i = 0; i < r; i++)
 			least = std::min(least, data[index[i]]);
 		return least;
 	}
 
-	float Assign(const int* index, float with) const {
+	double Assign(const unsigned long* index, double with) const {
 		for (int i = 0; i < r; i++)
 			data[index[i]] = with;
 		return with;
 	}
 
-	void Add(const int* index, float by = 1) const {
+	void Add(const unsigned long* index, double by = 1) const {
 		for (int i = 0; i < r; i++)
 			data[index[i]] += by;
 	}

--- a/src/CountMinSketch.hpp
+++ b/src/CountMinSketch.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <algorithm>
+#include <string>
 
 namespace MIDAS {
 struct CountMinSketch {

--- a/src/FilteringCore.hpp
+++ b/src/FilteringCore.hpp
@@ -21,78 +21,103 @@
 #include "CountMinSketch.hpp"
 
 namespace MIDAS {
-struct FilteringCore {
-	const float threshold;
-	int timestamp = 1;
-	const float factor;
-	const int lenData;
-	int* const indexEdge; // Pre-compute the index to-be-modified, thanks to the Same-Layout Assumption
-	int* const indexSource;
-	int* const indexDestination;
-	CountMinSketch numCurrentEdge, numTotalEdge, scoreEdge;
-	CountMinSketch numCurrentSource, numTotalSource, scoreSource;
-	CountMinSketch numCurrentDestination, numTotalDestination, scoreDestination;
-	float timestampReciprocal = 0;
-	bool* const shouldMerge;
+    struct FilteringCore {
+        const double threshold;
+        unsigned long timestamp = 1;
+        const double factor;
+        const int lenData;
+        unsigned long *const indexEdge; // Pre-compute the index to-be-modified, thanks to the Same-Layout Assumption
+        unsigned long *const indexSource;
+        unsigned long *const indexDestination;
+        CountMinSketch numCurrentEdge, numTotalEdge, scoreEdge;
+        CountMinSketch numCurrentSource, numTotalSource, scoreSource;
+        CountMinSketch numCurrentDestination, numTotalDestination, scoreDestination;
+        double timestampReciprocal = 0;
+        bool *const shouldMerge;
 
-	FilteringCore(int numRow, int numColumn, float threshold, float factor = 0.5):
-		threshold(threshold),
-		factor(factor),
-		lenData(numRow * numColumn), // I assume all CMSs have same size, but Same-Layout Assumption is not that strict
-		indexEdge(new int[numRow]),
-		indexSource(new int[numRow]),
-		indexDestination(new int[numRow]),
-		numCurrentEdge(numRow, numColumn),
-		numTotalEdge(numCurrentEdge),
-		scoreEdge(numCurrentEdge),
-		numCurrentSource(numRow, numColumn),
-		numTotalSource(numCurrentSource),
-		scoreSource(numCurrentSource),
-		numCurrentDestination(numRow, numColumn),
-		numTotalDestination(numCurrentDestination),
-		scoreDestination(numCurrentDestination),
-		shouldMerge(new bool[numRow * numColumn]) { }
+        FilteringCore(int numRow, int numColumn, double threshold, double factor = 0.5) :
+                threshold(threshold),
+                factor(factor),
+                lenData(numRow *
+                        numColumn), // I assume all CMSs have same size, but Same-Layout Assumption is not that strict
+                indexEdge(new unsigned long[numRow]),
+                indexSource(new unsigned long[numRow]),
+                indexDestination(new unsigned long[numRow]),
+                numCurrentEdge(numRow, numColumn),
+                numTotalEdge(numCurrentEdge),
+                scoreEdge(numCurrentEdge),
+                numCurrentSource(numRow, numColumn),
+                numTotalSource(numCurrentSource),
+                scoreSource(numCurrentSource),
+                numCurrentDestination(numRow, numColumn),
+                numTotalDestination(numCurrentDestination),
+                scoreDestination(numCurrentDestination),
+                shouldMerge(new bool[numRow * numColumn]) {}
 
-	virtual ~FilteringCore() {
-		delete[] indexEdge;
-		delete[] indexSource;
-		delete[] indexDestination;
-		delete[] shouldMerge;
-	}
+        virtual ~FilteringCore() {
+            delete[] indexEdge;
+            delete[] indexSource;
+            delete[] indexDestination;
+            delete[] shouldMerge;
+        }
 
-	static float ComputeScore(float a, float s, float t) {
-		return s == 0 ? 0 : pow(a + s - a * t, 2) / (s * (t - 1)); // If t == 1, then s == 0, so no need to check twice
-	}
+        static double ComputeScore(double a, double s, double t) {
+            return s == 0 ? 0 : pow(a + s - a * t, 2) /
+                                (s * (t - 1)); // If t == 1, then s == 0, so no need to check twice
+        }
 
-	void ConditionalMerge(const float* current, float* total, const float* score) const {
-		for (int i = 0; i < lenData; i++)
-			shouldMerge[i] = score[i] < threshold;
-		for (int i = 0, I = lenData; i < I; i++) // Vectorization
-			total[i] += shouldMerge[i] * current[i] + (true - shouldMerge[i]) * total[i] * timestampReciprocal;
-	}
+        void ConditionalMerge(const double *current, double *total, const double *score) const {
+            for (int i = 0; i < lenData; i++)
+                shouldMerge[i] = score[i] < threshold;
+            for (int i = 0, I = lenData; i < I; i++) // Vectorization
+                total[i] += shouldMerge[i] * current[i] + (true - shouldMerge[i]) * total[i] * timestampReciprocal;
+        }
 
-	float operator()(int source, int destination, int timestamp) {
-		if (this->timestamp < timestamp) {
-			ConditionalMerge(numCurrentEdge.data, numTotalEdge.data, scoreEdge.data);
-			ConditionalMerge(numCurrentSource.data, numTotalSource.data, scoreSource.data);
-			ConditionalMerge(numCurrentDestination.data, numTotalDestination.data, scoreDestination.data);
-			numCurrentEdge.MultiplyAll(factor);
-			numCurrentSource.MultiplyAll(factor);
-			numCurrentDestination.MultiplyAll(factor);
-			timestampReciprocal = 1.f / (timestamp - 1); // So I can skip an if-statement
-			this->timestamp = timestamp;
-		}
-		numCurrentEdge.Hash(indexEdge, source, destination);
-		numCurrentEdge.Add(indexEdge);
-		numCurrentSource.Hash(indexSource, source);
-		numCurrentSource.Add(indexSource);
-		numCurrentDestination.Hash(indexDestination, destination);
-		numCurrentDestination.Add(indexDestination);
-		return std::max({
-			scoreEdge.Assign(indexEdge, ComputeScore(numCurrentEdge(indexEdge), numTotalEdge(indexEdge), timestamp)),
-			scoreSource.Assign(indexSource, ComputeScore(numCurrentSource(indexSource), numTotalSource(indexSource), timestamp)),
-			scoreDestination.Assign(indexDestination, ComputeScore(numCurrentDestination(indexDestination), numTotalDestination(indexDestination), timestamp)),
-		});
-	}
-};
+        static unsigned long HashStr(const char *str) {
+            unsigned long hash = 5381;
+            int c;
+            while ((c = *str++)) {
+                hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+            }
+            return hash;
+        }
+
+        double operator()(const char *source, const char *destination, unsigned long timestamp) {
+            unsigned long intSource = HashStr(source);
+            unsigned long intDestination = HashStr(destination);
+
+            return this->operator()(intSource, intDestination, timestamp);
+        }
+
+        double operator()(unsigned long source, unsigned long destination, unsigned long timestamp) {
+            if (this->timestamp < timestamp) {
+                ConditionalMerge(numCurrentEdge.data, numTotalEdge.data, scoreEdge.data);
+                ConditionalMerge(numCurrentSource.data, numTotalSource.data, scoreSource.data);
+                ConditionalMerge(numCurrentDestination.data, numTotalDestination.data, scoreDestination.data);
+                numCurrentEdge.MultiplyAll(factor);
+                numCurrentSource.MultiplyAll(factor);
+                numCurrentDestination.MultiplyAll(factor);
+                timestampReciprocal = 1.f / (timestamp - 1); // So I can skip an if-statement
+                this->timestamp = timestamp;
+            }
+            numCurrentEdge.Hash(indexEdge, source, destination);
+            numCurrentEdge.Add(indexEdge);
+            numCurrentSource.Hash(indexSource, source);
+            numCurrentSource.Add(indexSource);
+            numCurrentDestination.Hash(indexDestination, destination);
+            numCurrentDestination.Add(indexDestination);
+            return std::max({
+                                    scoreEdge.Assign(indexEdge,
+                                                     ComputeScore(numCurrentEdge(indexEdge), numTotalEdge(indexEdge),
+                                                                  timestamp)),
+                                    scoreSource.Assign(indexSource, ComputeScore(numCurrentSource(indexSource),
+                                                                                 numTotalSource(indexSource),
+                                                                                 timestamp)),
+                                    scoreDestination.Assign(indexDestination,
+                                                            ComputeScore(numCurrentDestination(indexDestination),
+                                                                         numTotalDestination(indexDestination),
+                                                                         timestamp)),
+                            });
+        }
+    };
 }

--- a/src/FilteringCore.hpp
+++ b/src/FilteringCore.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cmath>
+#include <string>
 
 #include "CountMinSketch.hpp"
 

--- a/src/FilteringCore.hpp
+++ b/src/FilteringCore.hpp
@@ -73,16 +73,15 @@ namespace MIDAS {
                 total[i] += shouldMerge[i] * current[i] + (true - shouldMerge[i]) * total[i] * timestampReciprocal;
         }
 
-        static unsigned long HashStr(const char *str) {
+        static unsigned long HashStr(const std::string &str) {
             unsigned long hash = 5381;
-            int c;
-            while ((c = *str++)) {
-                hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+            for (auto c: str) {
+                hash = ((hash << 5) + hash) + (unsigned long) c; /* hash * 33 + c */
             }
             return hash;
         }
 
-        double operator()(const char *source, const char *destination, unsigned long timestamp) {
+        double operator()(const std::string &source, const std::string &destination, unsigned long timestamp) {
             unsigned long intSource = HashStr(source);
             unsigned long intDestination = HashStr(destination);
 

--- a/src/FilteringCore.hpp
+++ b/src/FilteringCore.hpp
@@ -22,26 +22,26 @@
 
 namespace MIDAS {
 struct FilteringCore {
-	const double threshold;
-	unsigned long timestamp = 1;
-	const double factor;
-	const unsigned long lenData;
-	unsigned long* const indexEdge; // Pre-compute the index to-be-modified, thanks to the Same-Layout Assumption
-	unsigned long* const indexSource;
-	unsigned long* const indexDestination;
+	const float threshold;
+	int timestamp = 1;
+	const float factor;
+	const int lenData;
+	int* const indexEdge; // Pre-compute the index to-be-modified, thanks to the Same-Layout Assumption
+	int* const indexSource;
+	int* const indexDestination;
 	CountMinSketch numCurrentEdge, numTotalEdge, scoreEdge;
 	CountMinSketch numCurrentSource, numTotalSource, scoreSource;
 	CountMinSketch numCurrentDestination, numTotalDestination, scoreDestination;
-	double timestampReciprocal = 0;
+	float timestampReciprocal = 0;
 	bool* const shouldMerge;
 
-	FilteringCore(unsigned long numRow, unsigned long numColumn, double threshold, double factor = 0.5):
+	FilteringCore(int numRow, int numColumn, float threshold, float factor = 0.5):
 		threshold(threshold),
 		factor(factor),
 		lenData(numRow * numColumn), // I assume all CMSs have same size, but Same-Layout Assumption is not that strict
-		indexEdge(new unsigned long[numRow]),
-		indexSource(new unsigned long[numRow]),
-		indexDestination(new unsigned long[numRow]),
+		indexEdge(new int[numRow]),
+		indexSource(new int[numRow]),
+		indexDestination(new int[numRow]),
 		numCurrentEdge(numRow, numColumn),
 		numTotalEdge(numCurrentEdge),
 		scoreEdge(numCurrentEdge),
@@ -60,18 +60,18 @@ struct FilteringCore {
 		delete[] shouldMerge;
 	}
 
-	static double ComputeScore(double a, double s, double t) {
+	static float ComputeScore(float a, float s, float t) {
 		return s == 0 ? 0 : pow(a + s - a * t, 2) / (s * (t - 1)); // If t == 1, then s == 0, so no need to check twice
 	}
 
-	void ConditionalMerge(const double* current, double* total, const double* score) const {
-		for (unsigned long i = 0; i < lenData; i++)
+	void ConditionalMerge(const float* current, float* total, const float* score) const {
+		for (int i = 0; i < lenData; i++)
 			shouldMerge[i] = score[i] < threshold;
-		for (unsigned long i = 0, I = lenData; i < I; i++) // Vectorization
+		for (int i = 0, I = lenData; i < I; i++) // Vectorization
 			total[i] += shouldMerge[i] * current[i] + (true - shouldMerge[i]) * total[i] * timestampReciprocal;
 	}
 
-	double operator()(unsigned long source, unsigned long destination, unsigned long timestamp) {
+	float operator()(int source, int destination, int timestamp) {
 		if (this->timestamp < timestamp) {
 			ConditionalMerge(numCurrentEdge.data, numTotalEdge.data, scoreEdge.data);
 			ConditionalMerge(numCurrentSource.data, numTotalSource.data, scoreSource.data);

--- a/src/NormalCore.hpp
+++ b/src/NormalCore.hpp
@@ -22,12 +22,12 @@
 
 namespace MIDAS {
 struct NormalCore {
-	unsigned long timestamp = 1;
-	unsigned long* const index; // Pre-compute the index to-be-modified, thanks to the same structure of CMSs
+	int timestamp = 1;
+	int* const index; // Pre-compute the index to-be-modified, thanks to the same structure of CMSs
 	CountMinSketch numCurrent, numTotal;
 
-	NormalCore(unsigned long numRow, unsigned long numColumn):
-		index(new unsigned long[numRow]),
+	NormalCore(int numRow, int numColumn):
+		index(new int[numRow]),
 		numCurrent(numRow, numColumn),
 		numTotal(numCurrent) { }
 
@@ -35,11 +35,11 @@ struct NormalCore {
 		delete[] index;
 	}
 
-	static float ComputeScore(double a, double s, double t) {
+	static float ComputeScore(float a, float s, float t) {
 		return s == 0 || t - 1 == 0 ? 0 : pow((a - s / t) * t, 2) / (s * (t - 1));
 	}
 
-	float operator()(unsigned long source, unsigned long destination, unsigned long timestamp) {
+	float operator()(int source, int destination, int timestamp) {
 		if (this->timestamp < timestamp) {
 			numCurrent.ClearAll();
 			this->timestamp = timestamp;

--- a/src/NormalCore.hpp
+++ b/src/NormalCore.hpp
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <cmath>
-
 #include "CountMinSketch.hpp"
 
 namespace MIDAS {
@@ -39,16 +38,15 @@ namespace MIDAS {
             return s == 0 || t - 1 == 0 ? 0 : pow((a - s / t) * t, 2) / (s * (t - 1));
         }
 
-        static unsigned long HashStr(const char *str) {
+        static unsigned long HashStr(const std::string &str) {
             unsigned long hash = 5381;
-            int c;
-            while ((c = *str++)) {
-                hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+            for (auto c: str) {
+                hash = ((hash << 5) + hash) + (unsigned long) c; /* hash * 33 + c */
             }
             return hash;
         }
 
-        double operator()(const char *source, const char *destination, unsigned long timestamp) {
+        double operator()(const std::string &source, const std::string &destination, unsigned long timestamp) {
             unsigned long intSource = HashStr(source);
             unsigned long intDestination = HashStr(destination);
 

--- a/src/NormalCore.hpp
+++ b/src/NormalCore.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cmath>
+#include <string>
 #include "CountMinSketch.hpp"
 
 namespace MIDAS {

--- a/src/NormalCore.hpp
+++ b/src/NormalCore.hpp
@@ -22,12 +22,12 @@
 
 namespace MIDAS {
 struct NormalCore {
-	int timestamp = 1;
-	int* const index; // Pre-compute the index to-be-modified, thanks to the same structure of CMSs
+	unsigned long timestamp = 1;
+	unsigned long* const index; // Pre-compute the index to-be-modified, thanks to the same structure of CMSs
 	CountMinSketch numCurrent, numTotal;
 
-	NormalCore(int numRow, int numColumn):
-		index(new int[numRow]),
+	NormalCore(unsigned long numRow, unsigned long numColumn):
+		index(new unsigned long[numRow]),
 		numCurrent(numRow, numColumn),
 		numTotal(numCurrent) { }
 
@@ -35,11 +35,11 @@ struct NormalCore {
 		delete[] index;
 	}
 
-	static float ComputeScore(float a, float s, float t) {
+	static float ComputeScore(double a, double s, double t) {
 		return s == 0 || t - 1 == 0 ? 0 : pow((a - s / t) * t, 2) / (s * (t - 1));
 	}
 
-	float operator()(int source, int destination, int timestamp) {
+	float operator()(unsigned long source, unsigned long destination, unsigned long timestamp) {
 		if (this->timestamp < timestamp) {
 			numCurrent.ClearAll();
 			this->timestamp = timestamp;

--- a/src/RelationalCore.hpp
+++ b/src/RelationalCore.hpp
@@ -22,20 +22,20 @@
 
 namespace MIDAS {
 struct RelationalCore {
-	unsigned long timestamp = 1;
-	const double factor;
-	unsigned long* const indexEdge; // Pre-compute the index to-be-modified, thanks to the same structure of CMSs
-	unsigned long* const indexSource;
-	unsigned long* const indexDestination;
+	int timestamp = 1;
+	const float factor;
+	int* const indexEdge; // Pre-compute the index to-be-modified, thanks to the same structure of CMSs
+	int* const indexSource;
+	int* const indexDestination;
 	CountMinSketch numCurrentEdge, numTotalEdge;
 	CountMinSketch numCurrentSource, numTotalSource;
 	CountMinSketch numCurrentDestination, numTotalDestination;
 
-	RelationalCore(unsigned long numRow, unsigned long numColumn, double factor = 0.5):
+	RelationalCore(int numRow, int numColumn, float factor = 0.5):
 		factor(factor),
-		indexEdge(new unsigned long[numRow]),
-		indexSource(new unsigned long[numRow]),
-		indexDestination(new unsigned long[numRow]),
+		indexEdge(new int[numRow]),
+		indexSource(new int[numRow]),
+		indexDestination(new int[numRow]),
 		numCurrentEdge(numRow, numColumn),
 		numTotalEdge(numCurrentEdge),
 		numCurrentSource(numRow, numColumn),
@@ -49,11 +49,11 @@ struct RelationalCore {
 		delete[] indexDestination;
 	}
 
-	static double ComputeScore(double a, double s, double t) {
+	static float ComputeScore(float a, float s, float t) {
 		return s == 0 || t - 1 == 0 ? 0 : pow((a - s / t) * t, 2) / (s * (t - 1));
 	}
 
-	double operator()(unsigned long source, unsigned long destination, unsigned long timestamp) {
+	float operator()(int source, int destination, int timestamp) {
 		if (this->timestamp < timestamp) {
 			numCurrentEdge.MultiplyAll(factor);
 			numCurrentSource.MultiplyAll(factor);

--- a/src/RelationalCore.hpp
+++ b/src/RelationalCore.hpp
@@ -21,59 +21,76 @@
 #include "CountMinSketch.hpp"
 
 namespace MIDAS {
-struct RelationalCore {
-	int timestamp = 1;
-	const float factor;
-	int* const indexEdge; // Pre-compute the index to-be-modified, thanks to the same structure of CMSs
-	int* const indexSource;
-	int* const indexDestination;
-	CountMinSketch numCurrentEdge, numTotalEdge;
-	CountMinSketch numCurrentSource, numTotalSource;
-	CountMinSketch numCurrentDestination, numTotalDestination;
+    struct RelationalCore {
+        unsigned long timestamp = 1;
+        const double factor;
+        unsigned long *const indexEdge; // Pre-compute the index to-be-modified, thanks to the same structure of CMSs
+        unsigned long *const indexSource;
+        unsigned long *const indexDestination;
+        CountMinSketch numCurrentEdge, numTotalEdge;
+        CountMinSketch numCurrentSource, numTotalSource;
+        CountMinSketch numCurrentDestination, numTotalDestination;
 
-	RelationalCore(int numRow, int numColumn, float factor = 0.5):
-		factor(factor),
-		indexEdge(new int[numRow]),
-		indexSource(new int[numRow]),
-		indexDestination(new int[numRow]),
-		numCurrentEdge(numRow, numColumn),
-		numTotalEdge(numCurrentEdge),
-		numCurrentSource(numRow, numColumn),
-		numTotalSource(numCurrentSource),
-		numCurrentDestination(numRow, numColumn),
-		numTotalDestination(numCurrentDestination) { }
+        RelationalCore(int numRow, int numColumn, double factor = 0.5) :
+                factor(factor),
+                indexEdge(new unsigned long[numRow]),
+                indexSource(new unsigned long[numRow]),
+                indexDestination(new unsigned long[numRow]),
+                numCurrentEdge(numRow, numColumn),
+                numTotalEdge(numCurrentEdge),
+                numCurrentSource(numRow, numColumn),
+                numTotalSource(numCurrentSource),
+                numCurrentDestination(numRow, numColumn),
+                numTotalDestination(numCurrentDestination) {}
 
-	virtual ~RelationalCore() {
-		delete[] indexEdge;
-		delete[] indexSource;
-		delete[] indexDestination;
-	}
+        virtual ~RelationalCore() {
+            delete[] indexEdge;
+            delete[] indexSource;
+            delete[] indexDestination;
+        }
 
-	static float ComputeScore(float a, float s, float t) {
-		return s == 0 || t - 1 == 0 ? 0 : pow((a - s / t) * t, 2) / (s * (t - 1));
-	}
+        static double ComputeScore(double a, double s, double t) {
+            return s == 0 || t - 1 == 0 ? 0 : pow((a - s / t) * t, 2) / (s * (t - 1));
+        }
 
-	float operator()(int source, int destination, int timestamp) {
-		if (this->timestamp < timestamp) {
-			numCurrentEdge.MultiplyAll(factor);
-			numCurrentSource.MultiplyAll(factor);
-			numCurrentDestination.MultiplyAll(factor);
-			this->timestamp = timestamp;
-		}
-		numCurrentEdge.Hash(indexEdge, source, destination);
-		numCurrentEdge.Add(indexEdge);
-		numTotalEdge.Add(indexEdge);
-		numCurrentSource.Hash(indexSource, source);
-		numCurrentSource.Add(indexSource);
-		numTotalSource.Add(indexSource);
-		numCurrentDestination.Hash(indexDestination, destination);
-		numCurrentDestination.Add(indexDestination);
-		numTotalDestination.Add(indexDestination);
-		return std::max({
-			ComputeScore(numCurrentEdge(indexEdge), numTotalEdge(indexEdge), timestamp),
-			ComputeScore(numCurrentSource(indexSource), numTotalSource(indexSource), timestamp),
-			ComputeScore(numCurrentDestination(indexDestination), numTotalDestination(indexDestination), timestamp),
-		});
-	}
-};
+        static unsigned long HashStr(const char *str) {
+            unsigned long hash = 5381;
+            int c;
+            while ((c = *str++)) {
+                hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+            }
+            return hash;
+        }
+
+        double operator()(const char *source, const char *destination, unsigned long timestamp) {
+            unsigned long intSource = HashStr(source);
+            unsigned long intDestination = HashStr(destination);
+
+            return this->operator()(intSource, intDestination, timestamp);
+        }
+
+        double operator()(unsigned long source, unsigned long destination, unsigned long timestamp) {
+            if (this->timestamp < timestamp) {
+                numCurrentEdge.MultiplyAll(factor);
+                numCurrentSource.MultiplyAll(factor);
+                numCurrentDestination.MultiplyAll(factor);
+                this->timestamp = timestamp;
+            }
+            numCurrentEdge.Hash(indexEdge, source, destination);
+            numCurrentEdge.Add(indexEdge);
+            numTotalEdge.Add(indexEdge);
+            numCurrentSource.Hash(indexSource, source);
+            numCurrentSource.Add(indexSource);
+            numTotalSource.Add(indexSource);
+            numCurrentDestination.Hash(indexDestination, destination);
+            numCurrentDestination.Add(indexDestination);
+            numTotalDestination.Add(indexDestination);
+            return std::max({
+                                    ComputeScore(numCurrentEdge(indexEdge), numTotalEdge(indexEdge), timestamp),
+                                    ComputeScore(numCurrentSource(indexSource), numTotalSource(indexSource), timestamp),
+                                    ComputeScore(numCurrentDestination(indexDestination),
+                                                 numTotalDestination(indexDestination), timestamp),
+                            });
+        }
+    };
 }

--- a/src/RelationalCore.hpp
+++ b/src/RelationalCore.hpp
@@ -22,20 +22,20 @@
 
 namespace MIDAS {
 struct RelationalCore {
-	int timestamp = 1;
-	const float factor;
-	int* const indexEdge; // Pre-compute the index to-be-modified, thanks to the same structure of CMSs
-	int* const indexSource;
-	int* const indexDestination;
+	unsigned long timestamp = 1;
+	const double factor;
+	unsigned long* const indexEdge; // Pre-compute the index to-be-modified, thanks to the same structure of CMSs
+	unsigned long* const indexSource;
+	unsigned long* const indexDestination;
 	CountMinSketch numCurrentEdge, numTotalEdge;
 	CountMinSketch numCurrentSource, numTotalSource;
 	CountMinSketch numCurrentDestination, numTotalDestination;
 
-	RelationalCore(int numRow, int numColumn, float factor = 0.5):
+	RelationalCore(unsigned long numRow, unsigned long numColumn, double factor = 0.5):
 		factor(factor),
-		indexEdge(new int[numRow]),
-		indexSource(new int[numRow]),
-		indexDestination(new int[numRow]),
+		indexEdge(new unsigned long[numRow]),
+		indexSource(new unsigned long[numRow]),
+		indexDestination(new unsigned long[numRow]),
 		numCurrentEdge(numRow, numColumn),
 		numTotalEdge(numCurrentEdge),
 		numCurrentSource(numRow, numColumn),
@@ -49,11 +49,11 @@ struct RelationalCore {
 		delete[] indexDestination;
 	}
 
-	static float ComputeScore(float a, float s, float t) {
+	static double ComputeScore(double a, double s, double t) {
 		return s == 0 || t - 1 == 0 ? 0 : pow((a - s / t) * t, 2) / (s * (t - 1));
 	}
 
-	float operator()(int source, int destination, int timestamp) {
+	double operator()(unsigned long source, unsigned long destination, unsigned long timestamp) {
 		if (this->timestamp < timestamp) {
 			numCurrentEdge.MultiplyAll(factor);
 			numCurrentSource.MultiplyAll(factor);

--- a/src/RelationalCore.hpp
+++ b/src/RelationalCore.hpp
@@ -53,16 +53,15 @@ namespace MIDAS {
             return s == 0 || t - 1 == 0 ? 0 : pow((a - s / t) * t, 2) / (s * (t - 1));
         }
 
-        static unsigned long HashStr(const char *str) {
+        static unsigned long HashStr(const std::string &str) {
             unsigned long hash = 5381;
-            int c;
-            while ((c = *str++)) {
-                hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+            for (auto c: str) {
+                hash = ((hash << 5) + hash) + (unsigned long) c; /* hash * 33 + c */
             }
             return hash;
         }
 
-        double operator()(const char *source, const char *destination, unsigned long timestamp) {
+        double operator()(const std::string &source, const std::string &destination, unsigned long timestamp) {
             unsigned long intSource = HashStr(source);
             unsigned long intDestination = HashStr(destination);
 

--- a/src/RelationalCore.hpp
+++ b/src/RelationalCore.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cmath>
+#include <string>
 
 #include "CountMinSketch.hpp"
 


### PR DESCRIPTION
* Add hash function to generate numerical value when `src` and `dst` are strings
* Change all numerical data type from `float` to `double` and `int` to `long`